### PR TITLE
Lock the requirements of the package to fix a bug.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pynmrstar>=3.0.4
-plotly>=4.1.0
+plotly==4.5.4
 numpy>=1.15.0

--- a/setup.py
+++ b/setup.py
@@ -3,21 +3,19 @@ from setuptools import setup, find_packages
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-
-
 setup(name='pybmrb',
       version='1.2.98',
-      packages = ['pybmrb'],
+      packages=['pybmrb'],
       author='Kumaran Baskaran',
       author_email='baskaran@uchc.edu',
       description='PyBMRB provides tools to visualize chemical shift data in BMRB',
       long_description=long_description,
-      long_description_content_type = 'text/markdown',
+      long_description_content_type='text/markdown',
       keywords=['bmrb', 'hsqc', 'chemical shift', 'nmrstar', 'biomagresbank', 'biological magnetic resonance bank'],
       url='https://github.com/uwbmrb/PyBMRB',
-      package_data = {'pybmrb':['data/*','examples/*']},
-       install_requires = [
-            'pynmrstar',
-            'plotly',
-            'numpy'],
+      package_data={'pybmrb': ['data/*', 'examples/*']},
+      install_requires=[
+          'pynmrstar>=3.0.4',
+          'plotly==4.5.4',
+          'numpy>=1.15.0'],
       license='MIT')


### PR DESCRIPTION
Newer versions of  Plotly change the default behavior of certain graph types, so force a downgrade to 5.4.5 (current version is 5.12.0) to fix the issue.